### PR TITLE
Fix deployment job source branch

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,9 +1,13 @@
-name: Jekyll Deploy
+# Adapted from: https://github.com/joshlarsen/jekyll4-deploy-gh-pages
+# For https://michalspano.com
 
+name: Jekyll-based Website Deployment
+
+# Evaluate when to invoke the job
 on:
   push:
     branches:
-      - master
+      - main
 
 jobs:
   build_and_deploy:
@@ -21,6 +25,7 @@ jobs:
       - name: Build & Deploy to GitHub Pages
         uses: joshlarsen/jekyll4-deploy-gh-pages@master
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          GITHUB_REPOSITORY: ${{ secrets.GITHUB_REPOSITORY }}
-          GITHUB_ACTOR: ${{ secrets.GITHUB_ACTOR }}
+          # Secrets
+          GITHUB_TOKEN:       ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_REPOSITORY:  ${{ secrets.GITHUB_REPOSITORY }}
+          GITHUB_ACTOR:       ${{ secrets.GITHUB_ACTOR }}


### PR DESCRIPTION
## Fix deployment job source branch

This **PR** _fixes_ the default **source branch** for the deployment job from `master` to `main`. Additionally, some further documentation is added to the description of the **workflow**.

Resolves #6